### PR TITLE
Docker image for dev-cluster compatibility

### DIFF
--- a/.github/workflows/docker-build-publish.yml
+++ b/.github/workflows/docker-build-publish.yml
@@ -14,13 +14,6 @@ on:
   pull_request:
 
 jobs:
-  docker-security-build-node:
-    permissions:
-      contents: write
-      packages: write
-    uses: celestiaorg/.github/.github/workflows/reusable_dockerfile_pipeline.yml@v0.2.0 # yamllint disable-line rule:line-length
-    with:
-      dockerfile: Dockerfile
   docker-security-build-dev-cluster-image:
     permissions:
       contents: write

--- a/.github/workflows/docker-build-publish.yml
+++ b/.github/workflows/docker-build-publish.yml
@@ -14,10 +14,17 @@ on:
   pull_request:
 
 jobs:
-  docker-security-build:
+  docker-security-build-node:
     permissions:
       contents: write
       packages: write
     uses: celestiaorg/.github/.github/workflows/reusable_dockerfile_pipeline.yml@v0.2.0 # yamllint disable-line rule:line-length
     with:
       dockerfile: Dockerfile
+  docker-security-build-dev-cluster-image:
+    permissions:
+      contents: write
+      packages: write
+    uses: celestiaorg/.github/.github/workflows/reusable_dockerfile_pipeline.yml@v0.2.0 # yamllint disable-line rule:line-length
+    with:
+      dockerfile: Dockerfile.dev-cluster

--- a/Dockerfile.dev-cluster
+++ b/Dockerfile.dev-cluster
@@ -12,7 +12,7 @@
 
 FROM ghcr.io/celestiaorg/celestia-node:v0.11.0-rc5
 
-RUN apt-get update && apt-get -y install jq curl
+RUN apk update && apk --no-cache add jq curl
 
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["celestia"]

--- a/Dockerfile.dev-cluster
+++ b/Dockerfile.dev-cluster
@@ -12,7 +12,9 @@
 
 FROM ghcr.io/celestiaorg/celestia-node:v0.11.0-rc5
 
+USER root
 RUN apk update && apk --no-cache add jq curl
+USER celestia
 
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["celestia"]

--- a/Dockerfile.dev-cluster
+++ b/Dockerfile.dev-cluster
@@ -1,0 +1,18 @@
+# The purpose of this docker file is to produce the same image
+# as celestia-node:v0.11.0-rc5, but to also provide `jq` and `curl` to
+# query a celestia data availability layer and store the genesis.
+#
+# Its primary use is in integration tests and the dev cluster.
+#
+# NOTE: Because this image is built from Celestia's image, any changes
+# in this fork will not be reflected in the image. To update the image
+# after a change to this codebase, you must refactor this Dockerfile
+# to use our fork's image. At the time of this comment, all changes
+# to this fork are only Dockerfile changes, so this is not an issue.
+
+FROM ghcr.io/celestiaorg/celestia-node:v0.11.0-rc5
+
+RUN apt-get update && apt-get -y install jq curl
+
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["celestia"]


### PR DESCRIPTION
Part of https://github.com/astriaorg/dev-cluster/issues/38

We need to build a custom image from Celestia's node image so that we can have `jq` and `curl`. These were needed for k8s infrastructure support.

Notes:
* `apt-get` -> `apk`
* the celestia-node upstream image was refactored and now has a `celestia` user. I had to use `root` in our `Dockerfile` to install `jq` and `curl`, then switch back to `celestia`
* when building the original node image and our custom image, the original image gets the same tag, which then overwrites the custom image on push. the github action is from celestia's reusable actions and does not support passing in a custom prefix like `dev-cluster-`. 
* we really don't even need to build the node image though, because we aren't using it. we are simply using celestia's node image. instead of refactoring the github action to support a custom prefix, i chose to only build a single image: our custom image
* this fork is only contains `Dockerfile` changes currently. if a change to the actual codebase is needed, we will need to refactor our image building pipeline to build the node image from this codebase